### PR TITLE
backward compatability between erlang 16 and 17,18,19

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,7 @@
 {erl_opts, [ debug_info
            , warnings_as_errors
            , warn_export_all
+           , {platform_define, "^[0-9]+", namespaced_types}
            ]}.
 
 {eunit_opts, [verbose, {report, {eunit_surefire, [{dir, "."}]}}]}.

--- a/src/jesse_json_path.erl
+++ b/src/jesse_json_path.erl
@@ -9,14 +9,18 @@
 %% API for path management
 -export([new/0, new/1, push/2, pop/1, to_string/1]).
 
+-ifdef(namespaced_types).
+-type dict() :: dict:dict().
+-endif.
+
 -type elem_key_type() :: atom | binary | string | undefined.
 -type elem_type() :: list | elem_key_type().
 -type kvc_obj() :: kvc_obj_node() | [kvc_obj_node()] | list().
 -type kvc_key() :: binary() | atom() | string().
 -type proplist() :: [{kvc_key(), kvc_obj()}].
 -type kvc_obj_node() :: proplist() | {struct, proplist()}
-                      | dict:dict() | gb_tree:tree() | term().
--type typed_proplist() :: {proplist() | {gb_tree:tree(), gb_tree:tree()}, elem_type()}.
+                      | dict() | gb_trees:tree() | term().
+-type typed_proplist() :: {proplist() | {gb_trees:tree(), gb_trees:tree()}, elem_type()}.
 
 -type path() :: list().
 


### PR DESCRIPTION
### Problem
Current master branch is not compiling under erlang 16 any more.
built-in `dict()` type is deprecated in erlang 17 and removed in newer releases, but it produces warning in erlang 16.

### Soltution
Make the code compilable in both erlang 16 and newer releases via erlang preprocessor.