### PR TITLE
Fixed failing `rebar3 edoc`

### DIFF
--- a/src/jesse_json_path.erl
+++ b/src/jesse_json_path.erl
@@ -295,7 +295,7 @@ to_path(Value)                         -> "." ++ to_path_item(Value).
 %% @doc Return string representation of the given <code>Path</code> object.
 %%
 %% For example, if the path is constructed by pushing the following elements
-%%  <code><<"root">>, "object", <<"array">>, 12, item, <<"field">></code>
+%%  <code> &lt;&lt;"root">>, "object", &lt;&lt;"array">>, 12, item, &lt;&lt;"field">></code>
 %% the resulting path will be the following string:
 %%  <code>"root.object.array[12].item.field"</code>
 %% @end

--- a/src/jesse_schema_validator.erl
+++ b/src/jesse_schema_validator.erl
@@ -77,13 +77,13 @@
 -define(OBJECT,               <<"object">>).
 -define(STRING,               <<"string">>).
 
-%% @doc General error definition tuple
+%% General error definition tuple
 -type error() ::
     { 'schema_invalid', Schema :: jesse:json_term(), reason() } |
     { 'data_invalid',   Schema :: jesse:json_term(), reason(),
                         Data   :: jesse:json_term() }.
 
-%% @doc Uniform type of the error reasons
+%% Uniform type of the error reasons
 -type reason()  :: { 'missing_id_field', Field :: binary() }
                  | { 'missing_required_property', Name :: binary() }
                  | { 'missing_dependency', Name :: binary() }


### PR DESCRIPTION
The documentation could no longer be generated due to failures. 

If you want to document the types, you need to add them to the preamble of the module (before @end tag). It's very annoying that `<<root>>` is not accepted and needs to be html quoted... I know no better way.